### PR TITLE
Fix api daily today errors

### DIFF
--- a/app/api/daily/today/route.ts
+++ b/app/api/daily/today/route.ts
@@ -1,7 +1,8 @@
-import { auth } from '@clerk/nextjs/server'
+import { auth, currentUser } from '@clerk/nextjs/server'
 import { NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase/server'
 import { getTodayDate } from '@/lib/utils/date'
+import { getOrCreateProfile } from '@/lib/utils/profile'
 import type { DailyEntry } from '@/types'
 
 export async function GET() {
@@ -12,19 +13,24 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    // Get user profile
-    const profileResponse = await supabaseAdmin
-      .from('profiles')
-      .select('id, timezone, arc_start_date')
-      .eq('clerk_user_id', userId)
-      .single()
-
-    if (profileResponse.error || !profileResponse.data) {
-      return NextResponse.json({ error: 'Profile not found' }, { status: 404 })
+    // Get current user for email
+    const user = await currentUser()
+    
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
     }
 
-    // @ts-expect-error - Supabase type narrowing issue
-    const profile = profileResponse.data
+    const email = user.emailAddresses[0]?.emailAddress || 'user@example.com'
+
+    // Get or create user profile
+    const profile = await getOrCreateProfile(userId, email)
+
+    if (!profile) {
+      return NextResponse.json(
+        { error: 'Failed to create profile' },
+        { status: 500 }
+      )
+    }
 
     // Get today's date in user's timezone
     const todayDate = getTodayDate(profile.timezone)

--- a/app/api/stats/dashboard/route.ts
+++ b/app/api/stats/dashboard/route.ts
@@ -1,8 +1,9 @@
-import { auth } from '@clerk/nextjs/server'
+import { auth, currentUser } from '@clerk/nextjs/server'
 import { NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase/server'
 import { calculateStreaks } from '@/lib/utils/streak'
 import { calculateTargetCompletion } from '@/lib/utils/scoring'
+import { getOrCreateProfile } from '@/lib/utils/profile'
 import type { DailyEntry, DashboardStats } from '@/types'
 
 /**
@@ -17,19 +18,24 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    // Get user profile
-    const profileResponse = await supabaseAdmin
-      .from('profiles')
-      .select('id, arc_start_date')
-      .eq('clerk_user_id', userId)
-      .single()
-
-    if (profileResponse.error || !profileResponse.data) {
-      return NextResponse.json({ error: 'Profile not found' }, { status: 404 })
+    // Get current user for email
+    const user = await currentUser()
+    
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
     }
 
-    // @ts-expect-error - Supabase type narrowing issue
-    const profile = profileResponse.data
+    const email = user.emailAddresses[0]?.emailAddress || 'user@example.com'
+
+    // Get or create user profile
+    const profile = await getOrCreateProfile(userId, email)
+
+    if (!profile) {
+      return NextResponse.json(
+        { error: 'Failed to create profile' },
+        { status: 500 }
+      )
+    }
 
     // Fetch all daily entries
     const { data: entries, error: entriesError } = await supabaseAdmin

--- a/app/api/stats/scorecard/route.ts
+++ b/app/api/stats/scorecard/route.ts
@@ -1,6 +1,7 @@
-import { auth } from '@clerk/nextjs/server'
+import { auth, currentUser } from '@clerk/nextjs/server'
 import { NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase/server'
+import { getOrCreateProfile } from '@/lib/utils/profile'
 import type { DailyEntry, ScorecardData } from '@/types'
 
 /**
@@ -15,19 +16,24 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    // Get user profile
-    const profileResponse = await supabaseAdmin
-      .from('profiles')
-      .select('id, arc_start_date, timezone')
-      .eq('clerk_user_id', userId)
-      .single()
-
-    if (profileResponse.error || !profileResponse.data) {
-      return NextResponse.json({ error: 'Profile not found' }, { status: 404 })
+    // Get current user for email
+    const user = await currentUser()
+    
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
     }
 
-    // @ts-expect-error - Supabase type narrowing issue
-    const profile = profileResponse.data
+    const email = user.emailAddresses[0]?.emailAddress || 'user@example.com'
+
+    // Get or create user profile
+    const profile = await getOrCreateProfile(userId, email)
+
+    if (!profile) {
+      return NextResponse.json(
+        { error: 'Failed to create profile' },
+        { status: 500 }
+      )
+    }
 
     // Calculate date range (arc_start_date to arc_start_date + 90 days)
     const arcStartDate = new Date(profile.arc_start_date)

--- a/app/api/stats/streak/route.ts
+++ b/app/api/stats/streak/route.ts
@@ -1,7 +1,8 @@
-import { auth } from '@clerk/nextjs/server'
+import { auth, currentUser } from '@clerk/nextjs/server'
 import { NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase/server'
 import { calculateStreaks } from '@/lib/utils/streak'
+import { getOrCreateProfile } from '@/lib/utils/profile'
 import type { DailyEntry, StreakData } from '@/types'
 
 /**
@@ -16,19 +17,24 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    // Get user profile
-    const profileResponse = await supabaseAdmin
-      .from('profiles')
-      .select('id')
-      .eq('clerk_user_id', userId)
-      .single()
-
-    if (profileResponse.error || !profileResponse.data) {
-      return NextResponse.json({ error: 'Profile not found' }, { status: 404 })
+    // Get current user for email
+    const user = await currentUser()
+    
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
     }
 
-    // @ts-expect-error - Supabase type narrowing issue
-    const profile = profileResponse.data
+    const email = user.emailAddresses[0]?.emailAddress || 'user@example.com'
+
+    // Get or create user profile
+    const profile = await getOrCreateProfile(userId, email)
+
+    if (!profile) {
+      return NextResponse.json(
+        { error: 'Failed to create profile' },
+        { status: 500 }
+      )
+    }
 
     // Fetch all daily entries for streak calculation
     const { data: entries, error: entriesError } = await supabaseAdmin

--- a/lib/utils/profile.ts
+++ b/lib/utils/profile.ts
@@ -1,8 +1,8 @@
-import { supabase } from '@/lib/supabase/client'
+import { supabaseAdmin } from '@/lib/supabase/server'
 import { DEFAULT_TIMEZONE } from '@/lib/constants/targets'
 
 /**
- * Get or create user profile for Clerk user
+ * Get or create user profile for Clerk user (Server-side version)
  * @param clerkUserId - Clerk user ID
  * @param email - User email
  * @returns User profile or null if error
@@ -13,7 +13,7 @@ export async function getOrCreateProfile(
 ): Promise<{ id: string; clerk_user_id: string; email: string; timezone: string; arc_start_date: string } | null> {
   try {
     // Check if profile exists
-    let { data: profile, error: fetchError } = await supabase
+    let { data: profile, error: fetchError } = await supabaseAdmin
       .from('profiles')
       .select('*')
       .eq('clerk_user_id', clerkUserId)
@@ -25,7 +25,7 @@ export async function getOrCreateProfile(
     }
 
     // Create new profile
-    const { data: newProfile, error: createError } = await supabase
+    const { data: newProfile, error: createError } = await supabaseAdmin
       .from('profiles')
       // @ts-ignore - Supabase type narrowing issue
       .insert({


### PR DESCRIPTION
Update all API routes to automatically create user profiles and fix `getOrCreateProfile` to use `supabaseAdmin` to resolve "Profile not found" errors for new users.

The `/api/daily/today` and other API endpoints were failing for new users because they expected a profile to exist but didn't create one if missing. Additionally, the `getOrCreateProfile` utility was incorrectly using the client-side Supabase instance in server-side API routes. This PR ensures all relevant API routes now correctly create a profile if one doesn't exist and that the profile creation logic uses the server-side Supabase instance.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d62aebd-9cb1-4a9d-bd94-633647be8541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d62aebd-9cb1-4a9d-bd94-633647be8541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

