### PR TITLE
Investigate and fix previous day data fetch issue

### DIFF
--- a/app/api/stats/scorecard/route.ts
+++ b/app/api/stats/scorecard/route.ts
@@ -55,13 +55,20 @@ export async function GET() {
     console.log('[Scorecard] Today (user TZ):', todayStr)
     console.log('[Scorecard] Today (UTC):', today.toISOString())
     console.log('[Scorecard] Arc start:', profile.arc_start_date)
+    console.log('[Scorecard] Arc end:', arcEndDate.toISOString().split('T')[0])
 
-    // Fetch all daily entries in the 90-day range
+    // Calculate the upper bound: min(arcEndDate, today)
+    const upperBoundDate = arcEndDate < today ? arcEndDate : today
+    const upperBoundStr = upperBoundDate.toISOString().split('T')[0]
+    console.log('[Scorecard] Upper bound for query:', upperBoundStr)
+    
+    // Fetch all daily entries in the 90-day range, up to today or arc end (whichever is earlier)
     const { data: entries, error: entriesError } = await supabaseAdmin
       .from('daily_entries')
       .select('entry_date, daily_score')
       .eq('user_id', profile.id)
       .gte('entry_date', profile.arc_start_date)
+      .lte('entry_date', upperBoundStr)
       .order('entry_date', { ascending: true })
 
     if (entriesError) {


### PR DESCRIPTION
Add an upper bound filter to database queries in stats APIs to fix incorrect previous day data fetching.

The database queries in the Scorecard, Dashboard, and Streak APIs were missing an upper bound filter (`.lte()` clause), causing them to fetch data beyond the current day or the arc end date. This resulted in inconsistent and incorrect data display for previous days. The fix ensures all stats APIs only fetch data within the valid arc period, up to today or the arc end date, whichever is earlier.

---
<a href="https://cursor.com/background-agent?bcId=bc-1190ab5f-65ec-4d1b-9ecd-f41164e24941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1190ab5f-65ec-4d1b-9ecd-f41164e24941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

